### PR TITLE
UX: fix can manage column overlap

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -3,5 +3,5 @@
 }
 
 .group-members--can-manage {
-  grid-template-columns: 3fr 40px repeat(4, minmax(min-content, 1fr)) 3em;
+   grid-template-columns: 3fr repeat(5, minmax(min-content, 1fr)) 3em; 
 }

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -3,5 +3,5 @@
 }
 
 .group-members--can-manage {
-  grid-template-columns: 3fr repeat(5, minmax(min-content, 1fr)) 3em; 
+  grid-template-columns: 3fr repeat(5, minmax(min-content, 1fr)) 3em;
 }

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -3,5 +3,5 @@
 }
 
 .group-members--can-manage {
-   grid-template-columns: 3fr repeat(5, minmax(min-content, 1fr)) 3em; 
+  grid-template-columns: 3fr repeat(5, minmax(min-content, 1fr)) 3em; 
 }


### PR DESCRIPTION
This PR adjusts the table so that when the can manage column is populated with Owner, it does not overlap the next proceeding column.

Before:
![CleanShot 2023-11-07 at 10 50 22](https://github.com/discourse/discourse-custom-fields-on-groups-list/assets/69276978/c1da6a7e-a93c-433b-a06c-fb319a78c342)

After:
![CleanShot 2023-11-07 at 10 50 55](https://github.com/discourse/discourse-custom-fields-on-groups-list/assets/69276978/5bc2b601-7edb-48b4-ab96-0f4c9eeb7d7d)
