### PR TITLE
FIX: Update order when header is clicked

### DIFF
--- a/javascripts/discourse/components/table-header-renderer.gjs
+++ b/javascripts/discourse/components/table-header-renderer.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
 import TableHeaderToggle from "discourse/components/table-header-toggle";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { USER_FIELD_PREFIX } from "../initializers/discourse-custom-fields-on-groups-list";
@@ -46,9 +47,16 @@ export default class TableHeaderRenderer extends Component {
     this._groupIndexController.set("asc", asc);
   }
 
+  @action
+  updateOrder(field, asc) {
+    this.order = field;
+    this.asc = asc;
+  }
+
   <template>
     {{#each this.filteredUserFields as |userField|}}
       <TableHeaderToggle
+        @onToggle={{this.updateOrder}}
         @order={{this.order}}
         @asc={{this.asc}}
         @translated={{true}}


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/29209, we introduced a new callback to update the order of the header to its parent. There is a current failing test with this component, this PR ensures this component is using the callback.