### PR TITLE
DEV: Use model extension APIs instead of modifyClass

### DIFF
--- a/javascripts/discourse/initializers/discourse-custom-fields-on-groups-list.js
+++ b/javascripts/discourse/initializers/discourse-custom-fields-on-groups-list.js
@@ -1,23 +1,17 @@
-import { ajax } from "discourse/lib/ajax";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export const USER_FIELD_PREFIX = "user_field_";
 
 function initialize(api) {
-  const PLUGIN_ID = "discourse-custom-fields-on-groups-list";
+  api.registerValueTransformer("group-members-request", ({ value: opts }) => {
+    const params = { ...opts, include_custom_fields: true };
 
-  api.modifyClassStatic("model:group", {
-    pluginId: PLUGIN_ID,
-    loadMembers(name, opts) {
-      const params = { ...opts, include_custom_fields: true };
+    if (params.order?.startsWith(USER_FIELD_PREFIX)) {
+      params.order_field = params.order;
+      params.order = "custom_field";
+    }
 
-      if (params.order?.startsWith(USER_FIELD_PREFIX)) {
-        params.order_field = params.order;
-        params.order = "custom_field";
-      }
-
-      return ajax(`/groups/${name}/members.json`, { data: params });
-    },
+    return params;
   });
 }
 


### PR DESCRIPTION
Uses the group-members-request value transformer instead of overriding
Group.loadMembers via modifyClassStatic.